### PR TITLE
OpenTracing, Jaeger Client, nginx-opentracing, openresty

### DIFF
--- a/jaeger-client.rb
+++ b/jaeger-client.rb
@@ -1,0 +1,50 @@
+class JaegerClient < Formula
+  desc "C++ OpenTracing binding for Jaeger"
+  homepage "https://jaegertracing.io/"
+  url "https://github.com/jaegertracing/jaeger-client-cpp/archive/v0.3.0.tar.gz"
+  sha256 "6cd2520f40048747fbf8d511f8b82e1f072d7af88f3040590dce839ed1bd6d8c"
+
+  depends_on "cmake" => :build
+
+  fails_with :gcc do
+    cause "Segfaults when used"
+  end
+
+  def install
+    mkdir ".build" do
+      cmake_args = std_cmake_args + %w[
+        -DBUILD_SHARED_LIBS=1
+        -DBUILD_TESTING=OFF
+      ]
+
+      cc = ENV.cc
+      cxx = ENV.cxx
+
+      begin
+        # cmake barfs on https://github.com/ruslo/hunter/wiki/error.no.toolchain.info
+        # no idea how to make it work other than to get rid of Homebrew clang wrappers
+        ENV["CC"] = "/usr/bin/clang"
+        ENV["CXX"] = "/usr/bin/clang++"
+        system "cmake", "..", *cmake_args
+      ensure
+        ENV["CC"] = cc
+        ENV["CXX"] = cxx
+      end
+
+      system "make", "install"
+    end
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test jaeger-client-cpp`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/nginx-opentracing.rb
+++ b/nginx-opentracing.rb
@@ -1,0 +1,16 @@
+class NginxOpentracing < Formula
+  desc "NGINX plugin for OpenTracing"
+  homepage "https://github.com/opentracing-contrib/nginx-opentracing"
+  url "https://github.com/opentracing-contrib/nginx-opentracing/archive/v0.3.0.tar.gz"
+  sha256 "2d2b8784a09c7bb4ae7f8a76ab679c54a683b8dda26db2f948982de0ad44c7a5"
+  bottle :unneeded
+  depends_on "opentracing" => :build
+
+  def install
+    pkgshare.install Dir["opentracing/*"]
+  end
+
+  test do
+    File.exist? pkgshare/"opentracing"/"config"
+  end
+end

--- a/openresty.rb
+++ b/openresty.rb
@@ -1,0 +1,21 @@
+# Quite nasty, but it allows to extend existing formula without copying it.
+Openresty = Formula["openresty/brew/openresty"].class
+Openresty.class_eval do
+  depends_on "nginx-opentracing" => :build
+  depends_on "opentracing" => :build
+  conflicts_with "openresty/brew/openresty", :because => "this extends the openresty formula"
+
+  option "with-dynamic-modules", "Compile OpenTracing as Nginx dynamic module"
+
+  def system(cmd, *args)
+    case cmd
+    when "./configure"
+      nginx_opentracing = Formula["nginx-opentracing"].pkgshare
+      args << "--add-#{build.with?("dynamic-modules") ? "dynamic-module" : "module"}=#{nginx_opentracing}"
+      args.find { |arg| arg.start_with?("--with-cc-opt=") } << " -I#{Formula["opentracing"].opt_include}"
+      args.find { |arg| arg.start_with?("--with-ld-opt=") } << " -L#{Formula["opentracing"].opt_lib}"
+    end
+
+    super
+  end
+end

--- a/opentracing.rb
+++ b/opentracing.rb
@@ -1,0 +1,31 @@
+class Opentracing < Formula
+  desc "OpenTracing API for C++"
+  homepage "http://opentracing.io"
+  url "https://github.com/opentracing/opentracing-cpp/archive/v1.3.0.tar.gz"
+  sha256 "06dc5f9740d27dc4684399e491211be46a8069a10277f25513dadeb71199ce4c"
+  depends_on "cmake" => :build
+
+  def install
+    mkdir ".build" do
+      cmake_args = std_cmake_args + %w[
+        -DBUILD_SHARED_LIBS=1
+        -DBUILD_TESTING=OFF
+      ]
+      system "cmake", "..", *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    # `test do` will create, run in and delete a temporary directory.
+    #
+    # This test will fail and we won't accept that! For Homebrew/homebrew-core
+    # this will need to be a test that verifies the functionality of the
+    # software. Run the test with `brew test opentracing-cpp`. Options passed
+    # to `brew install` such as `--HEAD` also need to be provided to `brew test`.
+    #
+    # The installed folder is not in the path, so use the entire path to any
+    # executables being tested: `system "#{bin}/program", "do", "something"`.
+    system "false"
+  end
+end

--- a/opentracing.rb
+++ b/opentracing.rb
@@ -1,5 +1,5 @@
 class Opentracing < Formula
-  desc "OpenTracing API for C++"
+  desc "C++ OpenTracing API"
   homepage "http://opentracing.io"
   url "https://github.com/opentracing/opentracing-cpp/archive/v1.3.0.tar.gz"
   sha256 "06dc5f9740d27dc4684399e491211be46a8069a10277f25513dadeb71199ce4c"


### PR DESCRIPTION
OpenResty with OpenTracing dynamic module, Jaeger Client.

```shell
brew install 3scale/opentracing/openresty --with-dynamic-modules
brew install jaeger-client
```